### PR TITLE
Script Compatibility Mode v2.0.0: IDs only in reviewQueue

### DIFF
--- a/_posts/2021-08-18-script-compatibility-mode.md
+++ b/_posts/2021-08-18-script-compatibility-mode.md
@@ -10,6 +10,11 @@ type: Document
 Changes that are affected by the Script Compatibility Mode setting are tracked here. Scripts can check WaniKani's version by checking `window.WaniKani.version` to match against this list.
 
 Subscribe to the [mailing list](https://tofugu.us1.list-manage.com/subscribe?u=b7f2114d74e3cac96344f797c&id=8b79442fb1) get notified when this page is updated. Make sure to check **UserScript Affecting Changes**.
+**v2.0.0 (November 17, 2021)**
+- **Compatibility Mode Off**: 
+  - `$.jStorage.get("reviewQueue")` now contain ids instead of objects.
+  - The ids are retrieved from `/review/queue?minimal=true`. `/review/queue` still returns the full objects in Compatibility Mode.
+  - The objects are retrieved in a separate request to `/reviews/items?ids=1,2,3`, which returns the full objects for ids 1,2,3.
 
 **v1.2.0 (November 15, 2021)**
 - **Compatibility Mode Off**: Under lessons, the positioning of the batch list navigation has been moved from Javascript (calculations that fire on window resize) to CSS using flexbox and margins.


### PR DESCRIPTION
- **Compatibility Mode Off**: 
  - `$.jStorage.get("reviewQueue")` now contain ids instead of objects.
  - The ids are retrieved from `/review/queue?minimal=true`. `/review/queue` still returns the full objects in Compatibility Mode.
  - The objects are retrieved in a separate request to `/reviews/items?ids=1,2,3`, which returns the full objects for ids 1,2,3.

