### PR TITLE
Script Compatibility Mode v3.0.0: Convert Quiz Overlays to React

### DIFF
--- a/_posts/2021-08-18-script-compatibility-mode.md
+++ b/_posts/2021-08-18-script-compatibility-mode.md
@@ -10,6 +10,13 @@ type: Document
 Changes that are affected by the Script Compatibility Mode setting are tracked here. Scripts can check WaniKani's version by checking `window.WaniKani.version` to match against this list.
 
 Subscribe to the [mailing list](https://tofugu.us1.list-manage.com/subscribe?u=b7f2114d74e3cac96344f797c&id=8b79442fb1) get notified when this page is updated. Make sure to check **UserScript Affecting Changes**.
+
+**v3.0.0 (November 17, 2021)**
+- **Compatibility Mode Off**: The overlays that appear at the end of the lesson quiz have been converted to React. This does a few things that are breaking changes:
+  - The overlays no longer have IDs and are styled purely through Tailwind classes.
+  - Removes the `activateLessonReadyScreen` function from `lessons.js`. That function controlled overlay and button behavior.
+  - Updates the behavior of `listenStartQuiz` in `quiz.js` to generate and show the next set of lessons.
+
 **v2.0.0 (November 17, 2021)**
 - **Compatibility Mode Off**: 
   - `$.jStorage.get("reviewQueue")` now contain ids instead of objects.


### PR DESCRIPTION
**Compatibility Mode Off**: The overlays that appear at the end of the lesson quiz have been converted to React. This does a few things that are breaking changes:
- The overlays no longer have IDs and are styled purely through Tailwind classes.
- Removes the `activateLessonReadyScreen` function from `lessons.js`. That function controlled overlay and button behavior.
- Updates the behavior of `listenStartQuiz` in `quiz.js` to generate and show the next set of lessons.