### PR TITLE
update to GA4 tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 title: WaniKani Knowledge
 url: "https://knowledge.wanikani.com/"
 baseurl:
-google_analytics_key: UA-1960021-27
+google_analytics_key: G-ZX55THXPXZ
 disqus_shortname:
 newsletter_action:
 company_name: Tofugu LLC

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,12 +12,15 @@
 		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Montserrat:400,400i,700,700i|Quicksand:400,700|Inconsolata:400,700">
 
 		{% if jekyll.environment == 'production' and site.google_analytics_key != '' %}
-			<script>
-				window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-				ga('create', '{{ site.google_analytics_key }}', 'auto');
-				ga('send', 'pageview');
-			</script>
-			<script async src='https://www.google-analytics.com/analytics.js'></script>
+
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_key }}"></script>
+      <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ site.google_analytics_key }}');
+      </script>
 		{% endif %}
 
 		{% seo %}


### PR DESCRIPTION
This PR updates the google tracking of the knowledge guide to use a new GA4 property as GA3 is being deprecated as of July this year.