### PR TITLE
Correct incorrect information about recent mistakes

### DIFF
--- a/_posts/2022-03-02-extra-study.md
+++ b/_posts/2022-03-02-extra-study.md
@@ -31,7 +31,7 @@ Use Extra Study’s Recent Mistakes mode to practice mistakes in reviews. You do
 
 **What’s considered a Recent Mistake?**
 
-Any item you’ve made a mistake on within the last 24 hours of doing reviews will be part of this mode. However, if you got an item right in the last hour, but you got it wrong 10 hours ago, it will not be part of Recent Mistakes.
+Any item you’ve made a mistake on within the last 24 hours of doing reviews will be part of this mode. However, in those 24 hours, if you get that item correct in reviews, it will be removed from Recent Mistakes at that time.
 
 Both Recent Lessons and Recent Mistakes are there to help you be successful in your Reviews. Use them as much as you’d like, but only if you have the time for it. It’s called _Extra_ Study for a reason, so don’t worry if you can’t get to them either.
 

--- a/_posts/2022-03-02-extra-study.md
+++ b/_posts/2022-03-02-extra-study.md
@@ -31,9 +31,9 @@ Use Extra Study’s Recent Mistakes mode to practice mistakes in reviews. You do
 
 **What’s considered a Recent Mistake?**
 
-Any item you’ve made a mistake on within the last 24 hours of doing reviews will be part of this mode. Even if you got an item right in the last hour, but you got it wrong 10 hours ago, it’ll be part of Recent Mistakes.
+Any item you’ve made a mistake on within the last 24 hours of doing reviews will be part of this mode. However, if you got an item right in the last hour, but you got it wrong 10 hours ago, it will not be part of Recent Mistakes.
 
-Both Recent Lessons and Recent Mistakes are there to help you be successful in your Reviews. Use them as much as you’d like, but only if you have the time for it. It’s called *Extra* Study for a reason, so don’t worry if you can’t get to them either.
+Both Recent Lessons and Recent Mistakes are there to help you be successful in your Reviews. Use them as much as you’d like, but only if you have the time for it. It’s called _Extra_ Study for a reason, so don’t worry if you can’t get to them either.
 
 **Burned Items**
 


### PR DESCRIPTION
When you get an item incorrect in reviews it shows up in Recent Mistakes. After 24 hours, it is removed from Recent Mistakes.

However, in those 24 hours, if you get that item correct in reviews, it will be removed from Recent Mistakes at that time.

Our Knowledge Guide says the opposite: an item remains in Recent Mistakes for 24 hours even if you get it correct again in reviews. This is false.

This PR changes the information in the Knowledge Guide to reflect how the app actually works.

Changes proposed in this pull request:

* Rewrote the sentence of the KG that gives false information.
